### PR TITLE
feat: refine surfaceId generation

### DIFF
--- a/packages/companion-surface-base/src/surface-api/detection.ts
+++ b/packages/companion-surface-base/src/surface-api/detection.ts
@@ -1,10 +1,14 @@
 import type EventEmitter from 'node:events'
-import type { DiscoveredSurfaceInfo } from './plugin.js'
+import type { DetectionSurfaceInfo } from './plugin.js'
 
 export interface SurfacePluginDetectionEvents<TInfo> {
 	/** Emitted when surfaces are detected */
-	surfacesAdded: [surfaceInfos: DiscoveredSurfaceInfo<TInfo>[]]
-	// surfacesRemoved: [surfaceIds: SurfaceId[]]
+	surfacesAdded: [surfaceInfos: DetectionSurfaceInfo<TInfo>[]]
+	/**
+	 * Emitted when discovered surfaces are lost
+	 * Note: This is important to call, to allow the id to be reused by a newly detected surface later on
+	 */
+	surfacesRemoved: [deviceHandles: string[]]
 }
 
 /**
@@ -22,5 +26,5 @@ export interface SurfacePluginDetection<TInfo> extends EventEmitter<SurfacePlugi
 	 * You can use this to cleanup any resources/handles for this surface, as it will not be used further
 	 * @param surfaceInfo The info about the surface which was rejected
 	 */
-	rejectSurface(surfaceInfo: DiscoveredSurfaceInfo<TInfo>): void
+	rejectSurface(surfaceInfo: DetectionSurfaceInfo<TInfo>): void
 }

--- a/packages/companion-surface-base/src/surface-api/plugin.ts
+++ b/packages/companion-surface-base/src/surface-api/plugin.ts
@@ -95,7 +95,11 @@ export interface DiscoveredSurfaceInfo<TInfo> {
 export interface DetectionSurfaceInfo<TInfo> extends DiscoveredSurfaceInfo<TInfo> {
 	/**
 	 * A stable unique identifier for the device.
-	 * Typically the device path if usb.
+	 *
+	 * This is the same logical concept that other interfaces may refer to as `devicePath`,
+	 * but is named `deviceHandle` here because, depending on the transport or platform,
+	 * it may not literally be a filesystem path. For USB devices it will typically be the
+	 * device path, while for other transports it can be another stable identifier.
 	 */
 	deviceHandle: string
 }

--- a/packages/companion-surface-base/src/surface-api/plugin.ts
+++ b/packages/companion-surface-base/src/surface-api/plugin.ts
@@ -90,7 +90,9 @@ export interface DiscoveredSurfaceInfo<TInfo> {
 }
 
 /**
- * Information about a discovered surface
+ * Information about a surface discovered via a detection/remote mechanism.
+ * Extends {@link DiscoveredSurfaceInfo} with a stable tracking handle (`deviceHandle`)
+ * that can be used to re-identify the same physical device between scans.
  */
 export interface DetectionSurfaceInfo<TInfo> extends DiscoveredSurfaceInfo<TInfo> {
 	/**

--- a/packages/companion-surface-base/src/surface-api/plugin.ts
+++ b/packages/companion-surface-base/src/surface-api/plugin.ts
@@ -97,6 +97,7 @@ export interface DiscoveredSurfaceInfo<TInfo> {
 export interface DetectionSurfaceInfo<TInfo> extends DiscoveredSurfaceInfo<TInfo> {
 	/**
 	 * A stable unique identifier for the device.
+	 * This is used to identify the same physical device between scans and operations, until it is disconnected. It is not shown to the user
 	 *
 	 * This is the same logical concept that other interfaces may refer to as `devicePath`,
 	 * but is named `deviceHandle` here because, depending on the transport or platform,

--- a/packages/companion-surface-base/src/surface-api/plugin.ts
+++ b/packages/companion-surface-base/src/surface-api/plugin.ts
@@ -68,10 +68,17 @@ export interface SurfacePlugin<TInfo> {
  */
 export interface DiscoveredSurfaceInfo<TInfo> {
 	/**
-	 * Id of the surface. Typically a serialnumber
+	 * Desired id of the surface. Typically a serialnumber.
+	 * It may not be opened with this id, as collisions may be resolved by the host
 	 * This does not have to be unique, if collisions are found it will be given a suffix to make it unique
 	 */
 	surfaceId: string
+	/**
+	 * Set this to true if the surface id is known to not be unique and should always be given a suffix
+	 * Otherwise, a suffix will only be added if a collision is detected
+	 */
+	surfaceIdIsNotUnique?: boolean
+
 	/**
 	 * Human friendly description of the surface. Typically a model name
 	 */

--- a/packages/companion-surface-base/src/surface-api/plugin.ts
+++ b/packages/companion-surface-base/src/surface-api/plugin.ts
@@ -50,7 +50,7 @@ export interface SurfacePlugin<TInfo> {
 	 * Perform a scan for devices, but not open them
 	 * Note: This should only be used if the plugin uses a protocol where we don't have other handling for
 	 */
-	scanForSurfaces?: () => Promise<DiscoveredSurfaceInfo<TInfo>[]>
+	scanForSurfaces?: () => Promise<DetectionSurfaceInfo<TInfo>[]>
 
 	/**
 	 * Open a discovered/known surface
@@ -68,7 +68,8 @@ export interface SurfacePlugin<TInfo> {
  */
 export interface DiscoveredSurfaceInfo<TInfo> {
 	/**
-	 * Unique id of the surface. Typically a serialnumber
+	 * Id of the surface. Typically a serialnumber
+	 * This does not have to be unique, if collisions are found it will be given a suffix to make it unique
 	 */
 	surfaceId: string
 	/**
@@ -79,4 +80,15 @@ export interface DiscoveredSurfaceInfo<TInfo> {
 	 * Plugin specific info about the surface
 	 */
 	pluginInfo: TInfo
+}
+
+/**
+ * Information about a discovered surface
+ */
+export interface DetectionSurfaceInfo<TInfo> extends DiscoveredSurfaceInfo<TInfo> {
+	/**
+	 * A stable unique identifier for the device.
+	 * Typically the device path if usb.
+	 */
+	deviceHandle: string
 }

--- a/packages/companion-surface-base/src/surface-api/remote.ts
+++ b/packages/companion-surface-base/src/surface-api/remote.ts
@@ -1,7 +1,7 @@
 import type EventEmitter from 'node:events'
 import type { OptionsObject, SomeCompanionInputField } from './input.js'
 import type { RemoteSurfaceConnectionInfo } from './types.js'
-import type { DetectionSurfaceInfo, DiscoveredSurfaceInfo } from './plugin.js'
+import type { DetectionSurfaceInfo } from './plugin.js'
 
 export interface SurfacePluginRemoteEvents<TInfo> {
 	surfacesConnected: [surfaceInfos: DetectionSurfaceInfo<TInfo>[]]
@@ -57,7 +57,7 @@ export interface SurfacePluginRemote<TInfo> extends EventEmitter<SurfacePluginRe
 	 * You can use this to cleanup any resources/handles for this surface, as it will not be used further
 	 * @param surfaceInfo The info about the surface which was rejected
 	 */
-	rejectSurface(surfaceInfo: DiscoveredSurfaceInfo<TInfo>): void
+	rejectSurface(surfaceInfo: DetectionSurfaceInfo<TInfo>): void
 }
 
 export interface DiscoveredRemoteSurfaceInfo {

--- a/packages/companion-surface-base/src/surface-api/remote.ts
+++ b/packages/companion-surface-base/src/surface-api/remote.ts
@@ -1,10 +1,10 @@
 import type EventEmitter from 'node:events'
 import type { OptionsObject, SomeCompanionInputField } from './input.js'
 import type { RemoteSurfaceConnectionInfo } from './types.js'
-import type { DiscoveredSurfaceInfo } from './plugin.js'
+import type { DetectionSurfaceInfo, DiscoveredSurfaceInfo } from './plugin.js'
 
 export interface SurfacePluginRemoteEvents<TInfo> {
-	surfacesConnected: [surfaceInfos: DiscoveredSurfaceInfo<TInfo>[]]
+	surfacesConnected: [surfaceInfos: DetectionSurfaceInfo<TInfo>[]]
 	// surfacesRemoved: [surfaceIds: SurfaceId[]]
 
 	/**

--- a/packages/companion-surface-host/src/context.ts
+++ b/packages/companion-surface-host/src/context.ts
@@ -2,6 +2,16 @@ import type { DiscoveredRemoteSurfaceInfo, SurfaceFirmwareUpdateInfo } from '@co
 import type { LockingGraphicsGenerator, HostCardGenerator } from './graphics.js'
 import type { CheckDeviceResult, OpenDeviceResult } from './types.js'
 
+/**
+ * Result of checking whether a discovered surface should be opened.
+ */
+export interface ShouldOpenSurfaceResult {
+	/** Whether the surface should be opened */
+	shouldOpen: boolean
+	/** The collision-resolved surface ID to use when opening the device */
+	resolvedSurfaceId: string
+}
+
 export interface SurfaceHostContext {
 	readonly lockingGraphics: LockingGraphicsGenerator
 	readonly cardsGenerator: HostCardGenerator
@@ -10,8 +20,21 @@ export interface SurfaceHostContext {
 
 	readonly surfaceEvents: HostSurfaceEvents
 
-	readonly shouldOpenDiscoveredSurface: (info: CheckDeviceResult) => Promise<boolean>
+	/**
+	 * Check whether a discovered surface should be opened.
+	 * This must be called before opening a detected surface to get the collision-resolved ID.
+	 * @param info - Information about the discovered device
+	 * @returns Result indicating if the surface should be opened and the resolved ID to use
+	 */
+	readonly shouldOpenDiscoveredSurface: (info: CheckDeviceResult) => Promise<ShouldOpenSurfaceResult>
 	readonly notifyOpenedDiscoveredSurface: (info: OpenDeviceResult) => Promise<void>
+
+	/**
+	 * Notify the host that discovered surfaces are no longer available.
+	 * This should be called when surfaces that were detected (but not necessarily opened) go away.
+	 * @param devicePaths - The device paths of the surfaces to forget
+	 */
+	readonly forgetDiscoveredSurfaces: (devicePaths: string[]) => void
 
 	readonly connectionsFound: (connectionInfos: DiscoveredRemoteSurfaceInfo[]) => void
 	readonly connectionsForgotten: (connectionIds: string[]) => void

--- a/packages/companion-surface-host/src/plugin.ts
+++ b/packages/companion-surface-host/src/plugin.ts
@@ -127,6 +127,7 @@ export class PluginWrapper<TInfo = unknown> {
 		return {
 			devicePath: hidDevice.path,
 			surfaceId: info.surfaceId,
+			surfaceIdIsNotUnique: !!info.surfaceIdIsNotUnique,
 			description: info.description,
 		}
 	}
@@ -159,6 +160,7 @@ export class PluginWrapper<TInfo = unknown> {
 		const shouldOpen = await this.#host.shouldOpenDiscoveredSurface({
 			devicePath: info.deviceHandle,
 			surfaceId: info.surfaceId,
+			surfaceIdIsNotUnique: !!info.surfaceIdIsNotUnique,
 			description: info.description,
 		})
 		this.#logger.info(
@@ -256,6 +258,7 @@ export class PluginWrapper<TInfo = unknown> {
 			// This is always set in v1.1 and later, but is missing in earlier versions
 			devicePath: r.deviceHandle || r.surfaceId,
 			surfaceId: r.surfaceId,
+			surfaceIdIsNotUnique: !!r.surfaceIdIsNotUnique,
 			description: r.description,
 		}))
 	}

--- a/packages/companion-surface-host/src/plugin.ts
+++ b/packages/companion-surface-host/src/plugin.ts
@@ -254,13 +254,17 @@ export class PluginWrapper<TInfo = unknown> {
 		// Cache these for when one is opened
 		this.#lastScannedDevices = results
 
-		return results.map((r) => ({
-			// This is always set in v1.1 and later, but is missing in earlier versions
-			devicePath: r.deviceHandle || r.surfaceId,
-			surfaceId: r.surfaceId,
-			surfaceIdIsNotUnique: !!r.surfaceIdIsNotUnique,
-			description: r.description,
-		}))
+		return (
+			results
+				.map((r) => ({
+					devicePath: r.deviceHandle,
+					surfaceId: r.surfaceId,
+					surfaceIdIsNotUnique: !!r.surfaceIdIsNotUnique,
+					description: r.description,
+				}))
+				// This is always set in v1.1 and later, but can be missing in earlier versions
+				.filter((r) => r.devicePath !== undefined)
+		)
 	}
 
 	async openScannedDevice(device: CheckDeviceResult, surfaceId: string): Promise<OpenDeviceResult | null> {

--- a/packages/companion-surface-host/src/types.ts
+++ b/packages/companion-surface-host/src/types.ts
@@ -20,6 +20,7 @@ export interface PluginFeatures {
 export interface CheckDeviceResult {
 	devicePath: string
 	surfaceId: string
+	surfaceIdIsNotUnique: boolean
 	description: string
 }
 

--- a/packages/companion-surface-host/src/types.ts
+++ b/packages/companion-surface-host/src/types.ts
@@ -18,6 +18,7 @@ export interface PluginFeatures {
 }
 
 export interface CheckDeviceResult {
+	devicePath: string
 	surfaceId: string
 	description: string
 }


### PR DESCRIPTION
Allows modules to return non-unique surfaceId values which will be translated to unique values in the open calls

https://github.com/bitfocus/companion/pull/3874